### PR TITLE
Fix types for character/line order

### DIFF
--- a/packages/cldr-types/src/general.ts
+++ b/packages/cldr-types/src/general.ts
@@ -1,7 +1,7 @@
 /**
  * @public
  */
-export type CharacterOrderType = 'ttb' | 'btt';
+export type CharacterOrderType = 'ltr' | 'rtl';
 
 /**
  * @public
@@ -11,7 +11,7 @@ export type ContextType = 'middle-of-text' | 'begin-sentence' | 'standalone' | '
 /**
  * @public
  */
-export type LineOrderType = 'ltr' | 'rtl';
+export type LineOrderType = 'ttb' | 'btt';
 
 /**
  * @public


### PR DESCRIPTION
The types currently given to the type aliases: "`CharacterOrderType`" and "`LineOrderType`" are the wrong way around.