### PR TITLE
Fix version utils json file import

### DIFF
--- a/packages/cldr-core/src/utils/version.ts
+++ b/packages/cldr-core/src/utils/version.ts
@@ -1,3 +1,3 @@
-import { version } from './pkginfo.json';
+import pkginfo from './pkginfo.json';
 
-export const VERSION = version;
+export const VERSION = pkginfo.version;


### PR DESCRIPTION
Per the [release notes for Webpack 5](https://webpack.js.org/blog/2020-10-10-webpack-5-release/#json-modules), named imports from json modules are now deprecated and also result in a runtime error when used in conjunction with strict mode.