### PR TITLE
Include cldr-patches directory to cldr-compiler packaging

### DIFF
--- a/packages/cldr-compiler/package.json
+++ b/packages/cldr-compiler/package.json
@@ -38,6 +38,7 @@
   },
   "files": [
     "bin",
+    "data/cldr-patches",
     "data/patches/rbnf",
     "lib/",
     "lib-es/"


### PR DESCRIPTION
We were getting a maximum stack depth error when building Finnish packs (due to missing `exemplarCity` field for America/Thule in CLDR).

The CLDR patch [`fi-timeZoneNames.yaml`](https://github.com/phensley/cldr-engine/blob/31811ae52bd27547e5b6e8d2bb1901b3a4cb57a6/packages/cldr-compiler/data/cldr-patches/fi-timeZoneNames.yaml) fixes the issue but wasn't included in the packaging for consumers.